### PR TITLE
Update GOPATH properly if no GOPATH is set

### DIFF
--- a/install/bash-it-custom/go.bash
+++ b/install/bash-it-custom/go.bash
@@ -1,3 +1,7 @@
 if [[ ! ":$GOPATH:" == *":$HOME/go:"* ]]; then
-    export GOPATH="$HOME/go:$GOPATH"
+    if [ -z "$GOPATH" ]; then
+       export GOPATH="$HOME/go"
+    else
+        export GOPATH="$HOME/go:$GOPATH"
+    fi
 fi


### PR DESCRIPTION
If GOPATH wasn't set before the script is run, `GOPATH` becomes `$HOME/go:` which is not read properly because of the extra colon at the end.

Thanks,
@swetharepakula
